### PR TITLE
add phantomjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "browserify": "^5.10.1",
     "function-bind": "^1.0.0",
+    "phantomjs": "^1.9.7-15",
     "run-browser": "^1.3.1",
     "tap-spec": "^0.2.1",
     "tape": "^2.14.0",


### PR DESCRIPTION
Required as a dev dependency so tests will run if it is not installed globally.
