### PR TITLE
dont rely on changed property for validity class

### DIFF
--- a/ampersand-input-view.js
+++ b/ampersand-input-view.js
@@ -102,9 +102,9 @@ module.exports = View.extend({
             }
         },
         validityClass: {
-            deps: ['valid', 'validClass', 'invalidClass', 'shouldValidate', 'changed'],
+            deps: ['valid', 'validClass', 'invalidClass', 'shouldValidate'],
             fn: function () {
-                if (!this.shouldValidate || !this.changed) {
+                if (!this.shouldValidate) {
                     return '';
                 } else {
                     return this.valid ? this.validClass : this.invalidClass;

--- a/test/basic.js
+++ b/test/basic.js
@@ -142,3 +142,74 @@ test('allow setting root element class', function (t) {
 
     t.end();
 });
+
+test('validityClass is present on submit even if unchanged', function (t) {
+    [
+        new InputView({
+            name: 'title',
+            required: true
+        }),
+        new InputView({
+            name: 'title',
+            required: true,
+            value: ''
+        })
+    ].forEach(function (input) {
+        input.render();
+
+        var inputElement = input.el.querySelector('input');
+        var messageContainer = input.el.querySelector('[data-hook=message-container]');
+
+        // "Trigger submit on the input"
+        // TODO: should we pull in form-view and do a dom submit event?
+        input.beforeSubmit();
+
+        t.notOk(input.valid, 'Input should be invalid');
+        t.notOk(isHidden(messageContainer), 'Message should be visible');
+        t.ok(hasClass(inputElement, 'input-invalid'), 'Has invalid class');
+        t.notOk(hasClass(inputElement, 'input-valid'), 'Does not have valid class');
+    });
+
+    t.end();
+});
+
+test('Required views display message and class after edited', function (t) {
+    [
+        new InputView({
+            name: 'title',
+            required: true
+        }),
+        new InputView({
+            name: 'title',
+            required: true,
+            value: ''
+        })
+    ].forEach(function (input) {
+        input.render();
+
+        var inputElement = input.el.querySelector('input');
+        var messageContainer = input.el.querySelector('[data-hook=message-container]');
+
+        inputElement.value = 'Required string';
+        input.handleInputChanged();
+        input.handleBlur();
+
+        t.ok(input.valid, 'Input should be valid');
+        t.ok(isHidden(messageContainer), 'Message should not be visible');
+        t.notOk(hasClass(inputElement, 'input-invalid'), 'Does not have invalid class');
+        t.ok(hasClass(inputElement, 'input-valid'), 'Has valid class');
+
+        // Changing the value back to an empty string should show invalid
+        // message and class even though it is technically "unchanged"
+        inputElement.value = '';
+        input.handleInputChanged();
+        input.handleBlur();
+
+        t.notOk(input.valid, 'Input should be invalid');
+        t.notOk(isHidden(messageContainer), 'Message should be visible');
+        t.ok(hasClass(inputElement, 'input-invalid'), 'Has invalid class');
+        t.notOk(hasClass(inputElement, 'input-valid'), 'Does not have valid class');
+    });
+
+    t.end();
+});


### PR DESCRIPTION
This is the same as #13 but I opened a new PR because even when calling `handleInputChanged` in `beforeSubmit` it would still hide the `validityClass` in cases where the input was "unchanged".

It seems like no matter what, once `shouldValidate` is true (like it gets set inside `beforeSubmit`) we should display the `validityClass`.

This PR just removes relying on `!this.changed` inside the `validityClass` derived property.
