### PR TITLE
Call handleInputChanged, when a file input changes.

### DIFF
--- a/ampersand-input-view.js
+++ b/ampersand-input-view.js
@@ -193,9 +193,11 @@ module.exports = View.extend({
     initInputBindings: function () {
         this.input.addEventListener('blur', this.handleBlur, false);
         this.input.addEventListener('input', this.handleInputChanged, false);
+        this.input.addEventListener('change', this.handleInputChanged, false);
     },
     remove: function () {
         this.input.removeEventListener('input', this.handleInputChanged, false);
+        this.input.removeEventListener('change', this.handleInputChanged, false);
         this.input.removeEventListener('blur', this.handleBlur, false);
         View.prototype.remove.apply(this, arguments);
     },


### PR DESCRIPTION
Validation for "file" typed input tags doesn't work, because "handleInputChanged" method currently gets triggered only on "input" event.