### PR TITLE
update docs for `required` default

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ When creating an instance of an input view, you can pass in the initial values o
 - template: a custom template to use (see 'template' section below for more).
 - placeholder: optional value used as placeholder in input.
 - el: optional element if you want to render it into a specific exisiting element pass it on initialization.
-- required (default: `false`): whether this field is required or not.
+- required (default: `true`): whether this field is required or not.
 - requiredMessage (default: `'This field is required'`): message to use if required and empty.
 - tests (default: `[]`): test function to run on input (more below).
 - validClass (defalt: `'input-valid'`): class to apply to input if valid.


### PR DESCRIPTION
`required` attribute is default to `true`, not `false`, as per this line https://github.com/tnguyen14/ampersand-input-view/blob/master/ampersand-input-view.js#L81. 

updating doc to reflect this. 

the other option is to change the code to have `required` set to false by default as per the doc.
