### PR TITLE
Doc update

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ When creating an instance of an input view, you can pass in the initial values o
 - tests (default: `[]`): test function to run on input (more below).
 - validClass (defalt: `'input-valid'`): class to apply to input if valid.
 - invalidClass (defalt: `'input-invalid'`): class to apply to input if invalid.
+- rootElementClass: class to apply to root element of view. 
 - parent: a view instance to use as the parent for this input. If used in a form view, the form sets this for you.
 
 
@@ -155,6 +156,8 @@ myInput.reset();
 console.log(myInput.input.value); //=> '&yet'
 ```
 
+### Customizing the view
+
 #### Custom calculated output `value`
 
 If you need to decouple what the user enters into the form from what the resulting value is that gets passed by the form you can do that by overwriting the `value` derived property.
@@ -210,6 +213,30 @@ var VerifiedAddressInput = AmpersandInputView.extend({
             this.verifiedAddress = result;
         });
     }
+});
+```
+
+#### Multiple classes for `rootElementClass`
+Another example might be that your designers want you to use multiple class names for the root element of your view. For example, `ui field` if you were using something like [Semantic UI](http://semantic-ui.com/).  You may want to try something like this:
+
+```javascript
+var styledInputView = new InputView({
+    // other properties
+    rootElementClass : 'ui field' // currently this doesn't work
+});
+```
+This is because `rootElementClass` needs to be a single class at least for now.  Luckily, its easy to customize this for your needs.  Since this view extends ampersand-view, you just need to extend it and overwrite `rootElementClass` to handle arrays:
+
+```javascript
+var CustomInputView = InputView.extend({
+    props : {
+        rootElementClass : ['array']
+    }
+});
+
+var styledInputView = new CustomInputView({
+    // other properties
+    rootElementClass : ['ui', 'field']
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ When creating an instance of an input view, you can pass in the initial values o
 
 #### opts
 
-- name (required): name to use for input tag name and name used when reporting to parent form.
+- name : name to use for input tag name and name used when reporting to parent form.
 - type (default: `'text'`): input type to use, can be any valid HTML5 input type.
 - value: initial value to set it to.
 - template: a custom template to use (see 'template' section below for more).

--- a/ampersand-input-view.js
+++ b/ampersand-input-view.js
@@ -74,7 +74,7 @@ module.exports = View.extend({
     props: {
         inputValue: 'any',
         startingValue: 'any',
-        name: 'string',
+        name: ['string', true, ''],
         type: ['string', true, 'text'],
         placeholder: ['string', true, ''],
         label: ['string', true, ''],

--- a/ampersand-input-view.js
+++ b/ampersand-input-view.js
@@ -74,7 +74,7 @@ module.exports = View.extend({
     props: {
         inputValue: 'any',
         startingValue: 'any',
-        name: ['string', true, ''],
+        name: 'string',
         type: ['string', true, 'text'],
         placeholder: ['string', true, ''],
         label: ['string', true, ''],


### PR DESCRIPTION
I found the documentation missing for `rootElementClass` so I figured I'd add it.  

I also threw in another section on customization in the docs.  I can remove this if you don't think it helpful.

Finally, the docs state that `name` is required, but it wasn't in the actual code.  I wasn't sure if it should be, but for now I figured do no harm and just update the docs to reflect reality. 