### PR TITLE
Enable usage of existing input

### DIFF
--- a/ampersand-input-view.js
+++ b/ampersand-input-view.js
@@ -66,8 +66,9 @@ module.exports = View.extend({
         }
     },
     render: function () {
-        if (!this.el) this.renderWithTemplate();
-        this.input = this.el || this.query('input') || this.query('textarea');
+        if (this.el) this.input = this.el;
+        this.el || this.renderWithTemplate();
+        this.input = this.input || this.query('input') || this.query('textarea');
         // switches out input for textarea if that's what we want
         this.handleTypeChange();
         this.initInputBindings();

--- a/ampersand-input-view.js
+++ b/ampersand-input-view.js
@@ -60,10 +60,14 @@ module.exports = View.extend({
         this.inputValue = value;
         this.on('change:valid change:value', this.reportToParent, this);
         if (spec.template) this.template = spec.template;
+        if (spec.el) {
+            this.el = spec.el;
+            this.render();
+        }
     },
     render: function () {
-        this.renderWithTemplate();
-        this.input = this.query('input') || this.query('textarea');
+        if (!this.el) this.renderWithTemplate();
+        this.input = this.el || this.query('input') || this.query('textarea');
         // switches out input for textarea if that's what we want
         this.handleTypeChange();
         this.initInputBindings();


### PR DESCRIPTION
# Problem statement
If a form uses `autoAppend: false`, it assumes that I am already providing an element to the form.  Indeed, on new InputView, I pass an `el`.  However, that el is disregarded, and no bindings are wired up.

# Solution
If an el is provided, set it, and call render immediately to wire the bindings/etc.  Only renderWithTemplate if there is no el present.