### PR TITLE
Feature/use el with validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ module.exports = FormView.extend({
 
 ### extend `AmpersandInputView.extend({ })`
 
-Since this view is based on [ampersand-state](http://ampersandjs.com/docs#ampersand-state), it can be extended in the same way. 
+Since this view is based on [ampersand-state](http://ampersandjs.com/docs#ampersand-state), it can be extended in the same way.
 
 To create an **`InputView`** class of your own, you extend **`AmpersandInputView`** and provide instance properties and options for your class. Here, you will typically pass any properties (`props`, `session`, and `derived`) of your state class, and any methods to be attached to instances of your class.
 
@@ -62,7 +62,7 @@ var MyCustomInput = AmpersandInputView.extend({
         AmpersandInputView.prototype.initialize.call(apply, arguments);
 
         // do whatever else you need to do on init here
-    } 
+    }
 });
 ```
 
@@ -79,13 +79,13 @@ When creating an instance of an `InputView`, you can pass in the initial values 
 - `value`: initial value for the `<input>`.
 - `template`: a custom template to use (see 'template' section, below, for more).
 - `placeholder`: (optional) “placeholder text” for the input.
-- `el`: (optional) element if you want to render it into a specific exisiting element pass it on initialization.
+- `el`: (optional) element if you want to render the field into a specific exisiting element.  If passed an `<input>` or `<textarea>`, a new container will replace your input, and make your input a child node (enabling the field validation features).
 - `required` (default: `true`): whether this field is required or not.
 - `requiredMessage` (default: `'This field is required'`): message to use if required and empty.
 - `tests` (default: `[]`): test function to run on input (more below).
 - `validClass`   (default: `'input-valid'`): class to apply to input if valid.
 - `invalidClass` (default: `'input-invalid'`): class to apply to input if invalid.
-- `rootElementClass`: class to apply to root element of view. 
+- `rootElementClass`: class to apply to root element of view.
 - `parent`: a View instance to use as the `parent` for this input. If your InputView is in a FormView, this is automatically set for you.
 
 
@@ -97,7 +97,7 @@ Renders the inputView. This is called automatically if your inputView is used wi
 
 This can either be customized by using `extend`, or by passing in a `template` on instantiation.
 
-It can be a function that returns a string of HTML or DOM element—or just an plain old HTML string. 
+It can be a function that returns a string of HTML or DOM element—or just an plain old HTML string.
 
 But whatever it is, the resulting HTML should contain the following hooks:
 
@@ -192,7 +192,7 @@ var VerifiedAddressInput = AmpersandInputView.extend({
             }
         },
         // you may also want to change what
-        // deterines if this field should be 
+        // deterines if this field should be
         // considerd valid. In this case, whether
         // it has a validated address
         valid: {
@@ -225,7 +225,7 @@ var styledInputView = new InputView({
     rootElementClass : 'ui field' // currently this doesn't work
 });
 ```
-This is because `rootElementClass` needs to be a single class (at least for now).  
+This is because `rootElementClass` needs to be a single class (at least for now).
 
 Luckily, its easy to customize this for your needs.  Since this view extends `ampersand-view`, you just need to extend it and override `rootElementClass` to handle arrays:
 
@@ -260,11 +260,11 @@ var myInput = new InputView({
                 return "A tweet can be no more than 140 characters";
             }
         }
-    ] 
+    ]
 });
 ```
 
-**Note:** You can still do `required: true` and pass tests. If you do, it will check if it's not empty first, and show the `requiredMessage` error if it is. 
+**Note:** You can still do `required: true` and pass tests. If you do, it will check if it's not empty first, and show the `requiredMessage` error if it is.
 
 Remember that the inputView will only show one error per field at a time. This is to minimize annoyance. We don't want to show “this field is required” and every other error if they just left it empty. We just show the first one that fails, then when they go to correct it, it will update to reflect the next failed test (if any).
 
@@ -278,7 +278,7 @@ Passing `true` as second argument will skip validation. This is mainly for inter
 
 ### reset `inputView.reset()`
 
-Set value to back original value. If you passed a `value` when creating the view it will reset to that, otherwise to `''`. 
+Set value to back original value. If you passed a `value` when creating the view it will reset to that, otherwise to `''`.
 
 
 ### clear `inputView.clear()`

--- a/ampersand-input-view.js
+++ b/ampersand-input-view.js
@@ -66,8 +66,9 @@ module.exports = View.extend({
         }
     },
     render: function () {
-        if (!this.el) this.renderWithTemplate();
-        this.input = this.el || this.query('input') || this.query('textarea');
+        if (this.el) this.input = this.el;
+        this.el || this.renderWithTemplate();
+        this.input = this.input || this.query('input') || this.query('textarea');
         // switches out input for textarea if that's what we want
         this.handleTypeChange();
         this.initInputBindings();

--- a/ampersand-input-view.js
+++ b/ampersand-input-view.js
@@ -1,7 +1,6 @@
 /*$AMPERSAND_VERSION*/
 var View = require('ampersand-view');
 
-
 module.exports = View.extend({
     template: [
         '<label>',
@@ -60,15 +59,23 @@ module.exports = View.extend({
         this.inputValue = value;
         this.on('change:valid change:value', this.reportToParent, this);
         if (spec.template) this.template = spec.template;
-        if (spec.el) {
-            this.el = spec.el;
+        if (spec.el && (spec.el.tagName === "INPUT" || spec.el.tagName === "TEXTAREA")) {
+            this.userInput = spec.el;
+            delete spec.el; // prevent view.set from overriding mutated el
             this.render();
         }
     },
     render: function () {
-        if (this.el) this.input = this.el;
-        this.el || this.renderWithTemplate();
-        this.input = this.input || this.query('input') || this.query('textarea');
+        this.renderWithTemplate();
+        this.input = this.query('input') || this.query('textarea');
+        if (this.userInput) {
+            // swap user input on first render
+            this.el.replaceChild(this.userInput, this.input);
+            // assume that if userInput provided, userLabel provided
+            this.el.removeChild(this.queryByHook('label'));
+            this.input = this.userInput;
+            delete this.userInput;
+        }
         // switches out input for textarea if that's what we want
         this.handleTypeChange();
         this.initInputBindings();

--- a/ampersand-input-view.js
+++ b/ampersand-input-view.js
@@ -60,10 +60,14 @@ module.exports = View.extend({
         this.inputValue = value;
         this.on('change:valid change:value', this.reportToParent, this);
         if (spec.template) this.template = spec.template;
+        if (spec.el) {
+            this.el = spec.el;
+            this.render();
+        }
     },
     render: function () {
-        this.renderWithTemplate();
-        this.input = this.query('input') || this.query('textarea');
+        if (!this.el) this.renderWithTemplate();
+        this.input = this.el || this.query('input') || this.query('textarea');
         // switches out input for textarea if that's what we want
         this.handleTypeChange();
         this.initInputBindings();


### PR DESCRIPTION
# Problem Statement

If I pass the FieldView an `el` which is an input, the validation nodes never render, and associated bindings/events never fire.

# Solution

Accommodate passing an input/textarea to the form.  Let user's know that their DOM will be mutated gently per the README.

1. Detect if passed el is an input
1. Render immediately, as the input itself is likely already rendered (and the form will likely be using `autoAppend: false`, otherwise you'd be less likely to provide an `el` to begin with)
1. Render the default template
1. Swap user specified input with default input

Review ignoring whitespace (sorry, truncated trailing spaces!): https://github.com/AmpersandJS/ampersand-input-view/pull/42/files?w=1