### PR TITLE
Handle case: value change and no DOM events emitted

### DIFF
--- a/ampersand-input-view.js
+++ b/ampersand-input-view.js
@@ -92,8 +92,14 @@ module.exports = View.extend({
         value: {
             deps: ['inputValue'],
             fn: function () {
+                if (this.input && this.input.value !== this.inputValue) {
+                    // handle case where input.value set directly,
+                    // which does not fire `input` event
+                    this.inputValue = this.input.value;
+                }
                 return this.inputValue;
-            }
+            },
+            cache: false
         },
         valid: {
             deps: ['inputValue'],


### PR DESCRIPTION
# Problem Statement
Periodically, the `.value` of an input is set directly.  This doesn't always fire `input` events.  Example, selecting a date on a jquery UI datepicker won't update the input FieldView's value.

# Solution
Check to see if `inputValue` and `this.input.value` have diverged when calling the `fieldView.value`.  To be successful, caching must be disabled as we can no longer rely on 'inputValue' alone to calculate the true field value.