### PR TITLE
uncache valid property

### DIFF
--- a/ampersand-input-view.js
+++ b/ampersand-input-view.js
@@ -100,6 +100,7 @@ module.exports = View.extend({
             }
         },
         valid: {
+            cache: false,
             deps: ['inputValue'],
             fn: function () {
                 return !this.runTests();

--- a/test/basic.js
+++ b/test/basic.js
@@ -371,3 +371,38 @@ test('initialize with a custom beforeSubmit', function (t) {
     t.equal(input.beforeSubmit, customBeforeSubmit);
     t.end();
 });
+
+test('input that is dependent on another', function (t) {
+    var inputOne = new InputView({
+        name: 'foo',
+        required: true
+    });
+
+    var inputTwo = new InputView({
+        name: 'bar',
+        required: false,
+        tests: [
+            function () {
+                if (inputOne.valid) {
+                    return 'Not valid';
+                }
+            }
+        ]
+    });
+    inputOne.render();
+    inputTwo.render();
+    var inputElement = inputTwo.el.querySelector('input');
+    var messageContainer = inputTwo.el.querySelector('[data-hook=message-container]');
+
+    t.notOk(inputOne.valid);
+    t.ok(inputTwo.valid);
+    inputOne.setValue('something');
+    // Since the only thing parent form evaluates on submit is the valid entry,
+    // we can simulated that by evaluating valid on both
+    t.ok(inputOne.valid);
+    t.notOk(inputTwo.valid);
+    t.ok(isHidden(messageContainer), 'Message should not be visible');
+    t.notOk(hasClass(inputElement, 'input-invalid'), 'Does not have invalid class');
+    t.notOk(hasClass(inputElement, 'input-valid'), 'Doest not have valid class');
+    t.end();
+});


### PR DESCRIPTION
Consider a form input whose valid state is dependent upon the values of other inputs in its parent form element.  Currently, there is no way for the derived `valid` property to be set differently based on anything other than an actual change to the inputValue itself.

With this small change one can at least rely on the re-running of the tests on form submission to catch these cases.  I'm not sure this is the perfect solution and am open to discussion about other ways to better handle this use case, it is one I have encountered in production already.