### PR TITLE
File type support and accept field

### DIFF
--- a/ampersand-input-view.js
+++ b/ampersand-input-view.js
@@ -184,7 +184,6 @@ module.exports = View.extend({
     handleChange: function () {
         if (this.type === 'file'){
             this.inputValue = this.input.files;
-            this.shouldValidate = true;
         }
         if (this.inputValue && this.changed) {
             this.shouldValidate = true;

--- a/ampersand-input-view.js
+++ b/ampersand-input-view.js
@@ -28,6 +28,11 @@ module.exports = View.extend({
             selector: 'input, textarea',
             name: 'name'
         },
+        'accept': {
+            type: 'attribute',
+            selector: 'input',
+            name: 'accept'
+        },
         'label': [
             {
                 hook: 'label'
@@ -81,6 +86,7 @@ module.exports = View.extend({
         startingValue: 'any',
         name: 'string',
         type: ['string', true, 'text'],
+        accept: ['string', true, ''],
         placeholder: ['string', true, ''],
         label: ['string', true, ''],
         required: ['boolean', true, true],
@@ -176,6 +182,10 @@ module.exports = View.extend({
     },
     //`change` event handler
     handleChange: function () {
+        if (this.type === 'file'){
+            this.inputValue = this.input.files;
+            this.shouldValidate = true;
+        }
         if (this.inputValue && this.changed) {
             this.shouldValidate = true;
         }


### PR DESCRIPTION
I've got an issue using `input` elements with `type='file'` because only the `change` event is fired on this case (no `input` event).

I've made a fork which solves the issue but, maybe not the right way, as I resort to an `if` to check the type on the event `change` handler. After a fast read in the #43 PR I realized that this may not be only an issue with the file picker.

Besides this I've also added the `accept` attribute field on the model and instead of returning the input value I return the files array in this case.

Don't know if this is the best approach (or maybe define a different `change` handler in case the input is of file type?) but please let me know and I'll be more than happy to help.