### PR TITLE
Use bindings for `readonly` option

### DIFF
--- a/ampersand-input-view.js
+++ b/ampersand-input-view.js
@@ -51,9 +51,9 @@ module.exports = View.extend({
             name: 'placeholder'
         },
         'readonly': {
-            type: "booleanAttribute",
-            name: "readonly",
-            selector: "input, textarea"
+            type: 'booleanAttribute',
+            name: 'readonly',
+            selector: 'input, textarea'
         }
     },
     initialize: function (spec) {

--- a/ampersand-input-view.js
+++ b/ampersand-input-view.js
@@ -49,6 +49,11 @@ module.exports = View.extend({
             type: 'attribute',
             selector: 'input, textarea',
             name: 'placeholder'
+        },
+        'readonly': {
+            type: "booleanAttribute",
+            name: "readonly",
+            selector: "input, textarea"
         }
     },
     initialize: function (spec) {
@@ -75,9 +80,6 @@ module.exports = View.extend({
         // Skip validation on initial setValue
         // if the field is not required
         this.setValue(this.inputValue, !this.required);
-        if (this.readonly) {
-            this.input.setAttribute('readonly', true);
-        }
         return this;
     },
     props: {


### PR DESCRIPTION
Based on changes in #61