### PR TITLE
bump ampersand-view to 10.0.0 for lodash 4.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "ampersand-dom": "^1.2.7",
     "ampersand-version": "^1.0.1",
-    "ampersand-view": "^9.0.0",
+    "ampersand-view": "^10.0.0",
     "matches-selector": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Bump version of ampersand-view so that lodash dependencies can be deduped.