### PR TITLE
Added the ability to reset validation state.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ When creating an instance of an `InputView`, you can pass in the initial values 
 - `parent`: a View instance to use as the `parent` for this input. If your InputView is in a FormView, this is automatically set for you.
 - `beforeSubmit`: function called by [ampersand-form-view](https://github.com/AmpersandJS/ampersand-form-view) during submit. By default this runs the tests and displays error messages.
 - `tabindex` (default: `0`): Specify the tab index number for your field (integer).
+- `clearValidationOnReset` (default: `false`): whether or not to clear validation class on field when it is reset by default.
 
 ### render `inputView.render()`
 Renders the inputView. This is called automatically if your inputView is used within a parent [ampersand-form-view](https://github.com/ampersandjs/ampersand-form-view).
@@ -270,23 +271,32 @@ $('[name=address]').datepicker({
 });
 ```
 
-### reset `inputView.reset()`
-Set value to back original value. If you passed a `value` when creating the view it will reset to that, otherwise to `''`.
+### reset `inputView.reset([resetValidation])`
+Set value to back original value. If you passed a `value` when creating the view it will reset to that, otherwise to `''`. Passing `true` to the method will clear validation state as well (`false` by default).
 
-### clear `inputView.clear()`
-Sets value to `''` no matter what previous values were.
+### clear `inputView.clear([resetValidation])`
+Sets value to `''` no matter what previous values were. Passing `true` to the method will clear validation state as well (`false` by default).
+
+### resetValidation `inputView.resetValidation()`
+Resets the validation state of the form field to its original state prior to any validation tests being ran on it.
 
 ## gotchas
 - Some browsers do not always fire a `change` event as expected.  In these [rare cases](https://github.com/AmpersandJS/ampersand-input-view/issues/2), validation may not occur when expected.  Validation _will occur_ regardless on form submission, specifically when this field's `beforeSubmit` executes.
 
 ## changelog
+- 7.1.0
+  - Add `resetValidation` functionality
+
 - 7.0.0
   - Upgrade to &-view 10.x (@RickButler #74)
   - Add `autofocus` option (@taketwo #73)
+
 - 6.0.0
   - Upgrade to &-view 9.x
+
 - 5.1.0
   - add `tabindex`
+
 - 5.0.0
   - Upgrade to &-view 8.x
   - Add `readonly` option

--- a/ampersand-input-view.js
+++ b/ampersand-input-view.js
@@ -109,7 +109,8 @@ module.exports = View.extend({
         validClass: ['string', true, 'input-valid'],
         invalidClass: ['string', true, 'input-invalid'],
         validityClassSelector: ['string', true, 'input, textarea'],
-        tabindex: ['number', true, 0]
+        tabindex: ['number', true, 0],
+        clearValidationOnReset: ['boolean', true, false]
     },
     derived: {
         value: {
@@ -148,7 +149,7 @@ module.exports = View.extend({
             }
         }
     },
-    setValue: function (value, skipValidation) {
+    setValue: function (value, skipValidation, resetValidation) {
         if (!this.input) {
             this.inputValue = value;
             return;
@@ -159,6 +160,10 @@ module.exports = View.extend({
             this.input.value = value.toString();
         }
         this.inputValue = this.clean(this.input.value);
+        if (resetValidation) {
+            this.resetValidation();
+            return;
+        }
         if (!skipValidation && !this.getErrorMessage()) {
             this.shouldValidate = true;
         } else if (skipValidation) {
@@ -238,9 +243,16 @@ module.exports = View.extend({
         View.prototype.remove.apply(this, arguments);
     },
     reset: function () {
+        resetValidation = resetValidation || this.clearValidationOnReset;
         this.setValue(this.startingValue, true); //Skip validation just like on initial render
     },
+    resetValidation: function() {
+        this.message = '';
+        this.shouldValidate = false;
+        this.render();
+    },
     clear: function () {
+        resetValidation = resetValidation || this.clearValidationOnReset;
         this.setValue('', true);
     },
     validityClassChanged: function (view, newClass) {


### PR DESCRIPTION
The functionality was added as an option to the module so that it is the default if the user chooses for it to be. It can also be ran with a new method `resetValidation` or via a parameter to the `clear` and `reset` methods.

This is useful when the same form is being reused without having to refresh the page or re-render the entire view.

The original functionality is retained as to not break backward-compatibility. This feature, in all cases, is purely optional. I updated the changelog portion of the README to reflect a minor update as their should be no breaking changes but it is not simply a bug patch.
