### PR TITLE
Don't change `type` property on textarea

### DIFF
--- a/ampersand-input-view.js
+++ b/ampersand-input-view.js
@@ -178,14 +178,16 @@ module.exports = View.extend({
         }
     },
     handleTypeChange: function () {
-        if (this.type === 'textarea' && this.input.tagName.toLowerCase() !== 'textarea') {
-            var parent = this.input.parentNode;
-            var textarea = document.createElement('textarea');
-            parent.replaceChild(textarea, this.input);
-            this.input = textarea;
-            this._applyBindingsForKey('');
-        } else {
-            this.input.type = this.type;
+        if (this.input.tagName.toLowerCase() !== 'textarea') {
+            if (this.type === 'textarea') {
+                var parent = this.input.parentNode;
+                var textarea = document.createElement('textarea');
+                parent.replaceChild(textarea, this.input);
+                this.input = textarea;
+                this._applyBindingsForKey('');
+            } else {
+                this.input.type = this.type;
+            }
         }
     },
     clean: function (val) {


### PR DESCRIPTION
Previously, the code would try to set a <textarea>'s `type` attribute to `this.type`. However, a textarea element's `type` property is readonly, and in some environments†, an Error is thrown:

```
Uncaught TypeError: Cannot assign to read only property 'type' of object '#<HTMLTextAreaElement>'
```

Now, the code behaves more or less the same way, but skips trying to assign `type` to textareas.

†I haven't been able to pinpoint why it happens sometimes and not others, but one major difference is browserify vs. rollup (Errors happen when using the latter).

---

This is a non-breaking change. However, I have spotted some other bugs, such as not handling switching from `"textarea"` type to non-`"textarea` type (aka an input element). That fix will come in another PR, and *will* be a breaking change.