### PR TITLE
[WIP] Allow changing to input element from textarea element when `type` is changed from `"textarea"`

### DIFF
--- a/ampersand-input-view.js
+++ b/ampersand-input-view.js
@@ -178,13 +178,23 @@ module.exports = View.extend({
         }
     },
     handleTypeChange: function () {
-        if (this.type === 'textarea' && this.input.tagName.toLowerCase() !== 'textarea') {
+        var tagname = this.input.tagName.toLowerCase();
+        
+        if (this.type === 'textarea' && tagname !== 'textarea') {
             var parent = this.input.parentNode;
             var textarea = document.createElement('textarea');
             parent.replaceChild(textarea, this.input);
             this.input = textarea;
             this._applyBindingsForKey('');
-        } else {
+        } else if (this.type !== 'textarea') {
+            if (tagname !== 'input') {
+                var parent = this.input.parentNode;
+                var input = document.createElement('input');
+                parent.replaceChild(input, this.input);
+                this.input = input;
+                this._applyBindingsForKey('');
+            }
+            
             this.input.type = this.type;
         }
     },


### PR DESCRIPTION
Before this change, when the inputView's `type` changed from "textarea" to something else ("text", "number", etc.), the `handleTypeChange` method would not handle changing the textarea to an input, like it would for changing an input to a textarea.

This builds on #77, a non-breaking change. This change, however, is a breaking one, and should be released as a major version after the previous PR gets released as a patch.

The reason this is a breaking change is because previously, setting `type` to "textarea" was not needed to render as a textarea. If "textarea" was in the `template` then `type` could be anything and it would not matter: a textarea would still render.

---

Todo:

- [ ] add tests
- [ ] version bump
- [ ] update documentation
- [ ] add release notes